### PR TITLE
C# Performance improvements

### DIFF
--- a/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/AsyncDuplicateLock.cs
+++ b/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/AsyncDuplicateLock.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace HaveIBeenPwned.PwnedPasswordsSpeedChallenge
+{
+    public sealed class AsyncDuplicateLock
+    {
+        private sealed class CountedValue<T>
+        {
+            public CountedValue(T value) => Value = value;
+
+            public int Count { get; set; } = 1;
+            public T Value { get; }
+        }
+
+        private static readonly Dictionary<object, CountedValue<SemaphoreSlim>> s_semaphores = new();
+
+        private static SemaphoreSlim GetOrCreate(object key)
+        {
+            lock (s_semaphores)
+            {
+                if (s_semaphores.TryGetValue(key, out CountedValue<SemaphoreSlim> item))
+                {
+                    ++item.Count;
+                }
+                else
+                {
+                    item = new CountedValue<SemaphoreSlim>(new SemaphoreSlim(1, 1));
+                    s_semaphores[key] = item;
+                }
+
+                return item.Value;
+            }
+        }
+
+        public static IDisposable Lock(object key)
+        {
+            GetOrCreate(key).Wait();
+            return new Releaser(key);
+        }
+
+        public static Task<IDisposable> LockAsync(object key)
+        {
+            SemaphoreSlim item = GetOrCreate(key);
+            return !item.Wait(0) ? LockAsyncImpl(item, key) : Task.FromResult<IDisposable>(new Releaser(key));
+        }
+
+        private static async Task<IDisposable> LockAsyncImpl(SemaphoreSlim item, object key)
+        {
+            await item.WaitAsync().ConfigureAwait(false);
+            return new Releaser(key);
+        }
+
+        private sealed class Releaser : IDisposable
+        {
+            public Releaser(object key) => Key = key;
+
+            public object Key { get; }
+
+            public void Dispose()
+            {
+                CountedValue<SemaphoreSlim> item;
+                lock (s_semaphores)
+                {
+                    item = s_semaphores[Key];
+                    --item.Count;
+                    if (item.Count == 0)
+                    {
+                        s_semaphores.Remove(Key);
+                    }
+                }
+
+                item.Value.Release();
+            }
+        }
+    }
+}

--- a/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/HashEntry.cs
+++ b/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/HashEntry.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+
+namespace HaveIBeenPwned.PwnedPasswordsSpeedChallenge
+{
+    internal readonly struct HashEntry : IComparable<HashEntry>
+    {
+        internal readonly ulong _highBytes;
+        internal readonly ulong _midBytes;
+        internal readonly ushort _lowBytes;
+        internal readonly uint _prevalence;
+        internal int Prevalence => (int)_prevalence;
+
+        internal HashEntry(ReadOnlySpan<byte> hashBytes, int prevalence)
+        {
+            if (hashBytes.Length == 18)
+            {
+                _highBytes = BinaryPrimitives.ReadUInt64BigEndian(hashBytes.Slice(0, 8));
+                _midBytes = BinaryPrimitives.ReadUInt64BigEndian(hashBytes.Slice(8, 8));
+                _lowBytes = BinaryPrimitives.ReadUInt16BigEndian(hashBytes.Slice(16, 2));
+                _prevalence = (uint)prevalence;
+            }
+            else
+            {
+                throw new ArgumentException($"{nameof(hashBytes)} does not contains 18 bytes of data.");
+            }
+        }
+
+        private HashEntry(ReadOnlySpan<byte> hashBytes)
+        {
+            BinaryPrimitives.TryReadUInt64BigEndian(hashBytes, out _highBytes);
+            BinaryPrimitives.TryReadUInt64BigEndian(hashBytes.Slice(8), out _midBytes);
+            BinaryPrimitives.TryReadUInt16BigEndian(hashBytes.Slice(16), out _lowBytes);
+            BinaryPrimitives.TryReadUInt32BigEndian(hashBytes.Slice(18), out _prevalence);
+        }
+
+        public int CompareTo(HashEntry other)
+        {
+            int result = _highBytes.CompareTo(other._highBytes);
+            if (result == 0)
+            {
+                result = _midBytes.CompareTo(other._midBytes);
+                if (result == 0)
+                {
+                    result = _lowBytes.CompareTo(other._lowBytes);
+                }
+            }
+
+            return result;
+        }
+
+        public bool TryWrite(Span<byte> span)
+        {
+            if (span.Length < 22)
+            {
+                return false;
+            }
+
+            BinaryPrimitives.TryWriteUInt64BigEndian(span, _highBytes);
+            BinaryPrimitives.TryWriteUInt64BigEndian(span.Slice(8), _midBytes);
+            BinaryPrimitives.TryWriteUInt16BigEndian(span.Slice(16), _lowBytes);
+            BinaryPrimitives.TryWriteUInt32BigEndian(span.Slice(18), _prevalence);
+
+            return true;
+        }
+
+        internal static bool TryParse(ReadOnlySpan<char> chars, out HashEntry entry)
+        {
+            if (chars.Length >= 37)
+            {
+                int colonIndex = chars.IndexOf(':');
+                if (colonIndex == 36)
+                {
+                    Span<byte> hashBytes = stackalloc byte[18];
+
+                    for (int i = 0; i < 18; i++)
+                    {
+                        hashBytes[i] = (byte)((HexCharToByte(chars[i * 2]) << 4) | HexCharToByte(chars[i * 2 + 1]));
+                    }
+
+                    if (int.TryParse(chars.Slice(colonIndex+1), out int prevalence))
+                    {
+                        entry = new HashEntry(hashBytes, prevalence);
+                        return true;
+                    }
+                }
+            }
+
+            entry = default;
+            return false;
+        }
+
+        internal static bool TryRead(Span<byte> span, out HashEntry entry)
+        {
+            if (span.Length >= 22)
+            {
+                entry = new HashEntry(span);
+                return true;
+            }
+
+            entry = default;
+            return false;
+        }
+
+        public bool Equals(HashEntry other) => _highBytes == other._highBytes && _midBytes == other._midBytes && _lowBytes == other._lowBytes;
+
+        internal static byte HexCharToByte(char hexChar) => hexChar switch
+        {
+            >= (char)48 and <= (char)57 => (byte)(hexChar - 48),
+            >= (char)65 and <= (char)70 => (byte)(hexChar - 55),
+            >= (char)97 and <= (char)102 => (byte)(hexChar - 87),
+            _ => 0,
+        };
+    }
+}

--- a/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/HaveIBeenPwned.PwnedPasswordsSpeedChallenge.csproj
+++ b/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/HaveIBeenPwned.PwnedPasswordsSpeedChallenge.csproj
@@ -11,6 +11,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+        <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
 		<PackageReference Include="Spectre.Console" Version="0.43.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
 	</ItemGroup>
 </Project>

--- a/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/Helpers.cs
+++ b/csharp/HaveIBeenPwned.PwnedPasswordsSpeedChallenge/Helpers.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Security.Cryptography;
+using System.Text;
+
+using Spectre.Console;
+
+namespace HaveIBeenPwned.PwnedPasswordsSpeedChallenge
+{
+    internal static class Helpers
+    {
+        private static readonly Encoding s_encoding = Encoding.UTF8;
+
+        internal static bool TryReadLine(ref ReadOnlySequence<byte> buffer, bool isComplete, out string? line)
+        {
+            while (buffer.Length > 0)
+            {
+                SequencePosition? position = buffer.PositionOf((byte)'\n');
+                if (position.HasValue)
+                {
+                    ReadOnlySequence<byte> slice = buffer.Slice(buffer.Start, position.Value);
+                    int sliceLength = (int)slice.Length;
+                    buffer = buffer.Slice(sliceLength + 1);
+                    line = s_encoding.GetString(slice.Slice(0, sliceLength)).Trim();
+                    return true;
+                }
+                else if (isComplete)
+                {
+                    // The pipe is complete but we don't have a newline character, this input probably ends without a newline char.
+                    line = s_encoding.GetString(buffer).Trim();
+                    buffer = buffer.Slice(buffer.End, 0);
+                    return true;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            line = "";
+            return false;
+        }
+
+        internal static void GetSha1Hash(this string password, Memory<byte> hashBytes)
+        {
+            int numBytesRequired = s_encoding.GetByteCount(password);
+            byte[] array = ArrayPool<byte>.Shared.Rent(numBytesRequired);
+            Span<byte> stringBytes = array.AsSpan(0, numBytesRequired);
+            s_encoding.GetBytes(password, stringBytes);
+            SHA1.TryHashData(stringBytes, hashBytes.Span, out _);
+            ArrayPool<byte>.Shared.Return(array);
+        }
+
+        internal static int CountLines(string inputFile)
+        {
+            int numLines = 0;
+
+            if (!File.Exists(inputFile))
+            {
+                AnsiConsole.MarkupLine($"[red]File not found[/]: {inputFile}");
+                return numLines;
+            }
+
+            using (FileStream file = File.OpenRead(inputFile))
+            {
+                using StreamReader fileReader = new(file);
+                string? line = fileReader.ReadLine();
+                while (line != null)
+                {
+                    if (!string.IsNullOrEmpty(line))
+                    {
+                        numLines++;
+                    }
+
+                    line = fileReader.ReadLine();
+                }
+            }
+
+            return numLines;
+        }
+
+        internal static async IAsyncEnumerable<string> ReadLinesAsync<T>(this T pipeReader) where T : PipeReader
+        {
+            while (true)
+            {
+                if (!pipeReader.TryRead(out ReadResult result))
+                {
+                    await pipeReader.ReadAsync().ConfigureAwait(false);
+                }
+
+                if (result.Buffer.IsEmpty && result.IsCompleted)
+                {
+                    break;
+                }
+
+                ReadOnlySequence<byte> buffer = result.Buffer;
+                while (TryReadLine(ref buffer, result.IsCompleted, out string? line))
+                {
+                    if (line != null)
+                    {
+                        yield return line;
+                    }
+                }
+
+                pipeReader.AdvanceTo(buffer.Start, buffer.End);
+            }
+        }
+
+        internal static async IAsyncEnumerable<string> ParseLinesAsync<T>(this T stream, int pauseThreshold = 1024 * 64, int resumeThreshold = 1024 * 32) where T : Stream
+        {
+            var inputPipe = new Pipe(new PipeOptions(pauseWriterThreshold: pauseThreshold, resumeWriterThreshold: resumeThreshold, useSynchronizationContext: false));
+            Task copyTask = stream.CopyToAsync(inputPipe.Writer).ContinueWith(CompleteWriter, inputPipe.Writer).Unwrap();
+
+            await foreach (string line in inputPipe.Reader.ReadLinesAsync())
+            {
+                yield return line;
+            }
+
+            await copyTask.ConfigureAwait(false);
+        }
+
+        internal static async Task CompleteWriter(Task previousTask, object? state)
+        {
+            if (previousTask.IsCompleted && state is PipeWriter pipeWriter)
+            {
+                var flushTask = pipeWriter.FlushAsync();
+                if (!flushTask.IsCompletedSuccessfully)
+                {
+                    await flushTask.ConfigureAwait(false);
+                }
+
+                await pipeWriter.CompleteAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Using pipelines to buffer and parse HIBP API requests.
* Using proper async I/O for both files and network requests.
* Using TLS 1.3
* Using HTTP/3
* Storing cache items as binary files to make them smaller and easier to parse and enabling binary search.
* Using pooled lists for loading hash entries to search through.

## New results

### Empty cache
<img width="811" alt="image" src="https://user-images.githubusercontent.com/661658/156552723-54fbb2c1-e121-435b-b6bf-a54d986912c6.png">

### Populated cache
<img width="854" alt="image" src="https://user-images.githubusercontent.com/661658/156553094-292280ee-c6aa-492e-a460-fe491dcff30c.png">

