### PR TITLE
feat: go implementation

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,0 +1,5 @@
+cache
+prevalence.txt
+output.txt
+input.txt
+psc

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,61 @@
+This folder contains the Go version of the PwnedPasswords Speed Challenge application.
+
+## Pre-Requisites
+
+You must have:
+
+- [Go](https://go.dev) Installed.
+- Have an `input.txt` file containing your password list in the `go` directory.
+
+## Running the application
+
+You can run the application without building it by running the following command in the `go` directory.
+
+```shell
+go run . --help
+```
+
+## Building the application
+
+You can build a native binary of the application by running the below command in the `go` directory:
+
+```go
+go build .
+```
+
+The binary can be executed by calling it from the command line:
+
+```shell
+./psc --help
+```
+
+## Command-line arguments
+
+You can access the command line arguments by using the `--help` flag as demonstrated above.
+
+```shell
+Usage of ./psc:
+  -clear-cache
+        Clear local cache and make API calls only.
+  -help
+        Display command-line arguments.
+  -parallelism int
+        Number of goroutines used to process passwords. (default 500)
+  -skip-cache
+        Skip local cache and make API calls only.
+```
+
+**Notes:**
+
+- The application accepts both `--` and `-` variations of argument prefix.
+- Although goroutines provide concurrency (which is not strictly parallelism) the `parallelism` phrase has been chosen for the flag to maintain consistency with the csharp implementation.
+
+# Potential Improvements
+
+This implementation could be further improved by:
+
+- Hashing all passwords upfront and grouping by SHA prefix to reduce the required API calls and disk IO.
+- Reduced mutex usage.
+- Better network handling:
+  - Error handling (Retries & exponential backoff)
+- Tests

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module psc
+
+go 1.20

--- a/go/lib/cache.go
+++ b/go/lib/cache.go
@@ -1,0 +1,40 @@
+package lib
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Check if a cache file exists.
+func CacheExists(shaPrefix string) bool {
+	file := fmt.Sprintf("cache/%s", shaPrefix)
+	_, err := os.ReadFile(file)
+
+	return err == nil
+}
+
+// Load a cache file.
+func LoadFromCache(shaPrefix string) []ApiResponse {
+	filename := fmt.Sprintf("cache/%s", shaPrefix)
+	var response []ApiResponse
+
+	file, _ := os.ReadFile(filename)
+	json.Unmarshal(file, &response)
+
+	return response
+}
+
+// Add a cache file for a SHA prefix.
+func AddToCache(shaPrefix string, content []ApiResponse) {
+	obj, err := json.Marshal(content)
+	if err != nil {
+		fmt.Println("Failed to marshal request data for creation.")
+	}
+
+	filename := fmt.Sprintf("cache/%s", shaPrefix)
+	err = os.WriteFile(filename, obj, 0644)
+	if err != nil {
+		fmt.Printf("Failed to write cache file for prefix: %s\nReason: %s \n", shaPrefix, err)
+	}
+}

--- a/go/lib/environment.go
+++ b/go/lib/environment.go
@@ -1,0 +1,98 @@
+package lib
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+type ResponseStatistics struct {
+	Mu            sync.Mutex
+	ResponseTimes []int64
+}
+
+type Environment struct {
+	StartTime       time.Time
+	ResponseStats   ResponseStatistics
+	ProcessedCount  uint64
+	ApiRequestCount int64
+	CfCachedCount   int64
+	Flags           Flags
+	AllPasswords    SafePasswordList
+	PasswordCh      chan *Password
+}
+
+type Flags struct {
+	SkipCache   *bool
+	ClearCache  *bool
+	Help        *bool
+	Parallelism *int
+}
+
+type SafePasswordList struct {
+	Mu           sync.Mutex
+	PasswordList PasswordList
+	LoaderWg     sync.WaitGroup
+}
+
+// Prepare the system and application before running.
+func SetupEnvironment() *Environment {
+	env := Environment{
+		StartTime: time.Now(),
+		Flags:     loadFlags(),
+		AllPasswords: SafePasswordList{
+			Mu:           sync.Mutex{},
+			PasswordList: make(PasswordList),
+			LoaderWg:     sync.WaitGroup{},
+		},
+	}
+	env.PasswordCh = make(chan *Password, *env.Flags.Parallelism)
+
+	handleHelp(env.Flags.Help)
+	prepLocalCache(env.Flags.ClearCache, env.Flags.SkipCache)
+
+	return &env
+}
+
+// Load command-line arguments.
+func loadFlags() Flags {
+	var flags = Flags{
+		ClearCache:  flag.Bool("clear-cache", false, "Clear local cache and make API calls only."),
+		SkipCache:   flag.Bool("skip-cache", false, "Skip local cache and make API calls only."),
+		Parallelism: flag.Int("parallelism", 500, "Number of goroutines used to process passwords."),
+		Help:        flag.Bool("help", false, "Display command-line arguments."),
+	}
+	flag.Parse()
+
+	return flags
+}
+
+// Handle the help flag.
+func handleHelp(help *bool) {
+	if *help {
+		flag.Usage()
+		os.Exit(0)
+	}
+}
+
+// Prepare the local cache directory.
+func prepLocalCache(clearCache *bool, skipCache *bool) {
+	if *clearCache {
+		os.RemoveAll("./cache")
+	}
+	createCacheDir()
+}
+
+// Create the local cache directory if it doesn't exist.
+func createCacheDir() {
+	err := os.Mkdir("cache", 0755)
+	if err != nil {
+		if err.Error() == "mkdir cache: file exists" {
+			return
+		}
+		fmt.Println(err)
+		return
+	}
+}

--- a/go/lib/network.go
+++ b/go/lib/network.go
@@ -1,0 +1,77 @@
+package lib
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type ApiResponse struct {
+	Suffix string
+	Count  int
+}
+
+// Structure the API response for caching.
+func StructureData(env *Environment, shaList []string) ([]ApiResponse, error) {
+	response := []ApiResponse{}
+
+	for _, item := range shaList {
+		shaProps := strings.Split(item, ":")
+		shaSuffix := shaProps[0]
+		rawCount := shaProps[1]
+
+		shaCount, err := strconv.Atoi(strings.TrimSpace(rawCount))
+		if err != nil {
+			return response, errors.New("can't parse sha count")
+		}
+
+		entry := ApiResponse{
+			Count:  shaCount,
+			Suffix: shaSuffix,
+		}
+
+		response = append(response, entry)
+
+	}
+	return response, nil
+}
+
+// Query the Pwned Passwords API and return the content.
+func QueryApi(env *Environment, sha string) ([]string, error) {
+	shaPrefix := sha[0:5]
+	url := fmt.Sprintf("https://api.pwnedpasswords.com/range/%s", shaPrefix)
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	req.Header.Set("User-Agent", "hibp-speedtest-go")
+
+	start := time.Now()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return []string{}, err
+	}
+	defer resp.Body.Close()
+
+	respTime := time.Since(start).Milliseconds()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return []string{}, err
+	}
+	bodyString := string(body)
+
+	apiCacheStatus := resp.Header.Get("CF-Cache-Status")
+	UpdateAPIStats(env, respTime, apiCacheStatus)
+
+	return strings.Split(bodyString, "\n"), nil
+}

--- a/go/lib/passwords.go
+++ b/go/lib/passwords.go
@@ -1,0 +1,119 @@
+package lib
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+)
+
+type Password struct {
+	Sha        string
+	Password   string
+	Prevalence int
+}
+
+type PasswordPrevalence struct {
+	Password   string
+	Prevalence int
+}
+
+type PasswordList map[string]PasswordPrevalence
+
+// Method to check if a password has already been loaded into the PasswordList.
+func (p *Password) IsLoaded(env *Environment) bool {
+	env.AllPasswords.Mu.Lock()
+	_, passwordPresent := env.AllPasswords.PasswordList[p.Sha]
+	env.AllPasswords.Mu.Unlock()
+
+	return passwordPresent
+}
+
+// Method to load a password from either cache or API.
+func (p *Password) Load(env *Environment) {
+	shaPrefix := p.Sha[0:5]
+	shaSuffix := p.Sha[5:]
+
+	var data []ApiResponse
+	cacheExists := CacheExists(shaPrefix)
+
+	flags := &env.Flags
+
+	if cacheExists && !*flags.SkipCache {
+		data = LoadFromCache(shaPrefix)
+	} else {
+		apiData, err := QueryApi(env, p.Sha)
+		if err != nil {
+			fmt.Printf("Failed to query API for password: %s \nReason: %s\n", p.Password, err)
+			return
+		}
+		data, err = StructureData(env, apiData)
+		if err != nil {
+			fmt.Printf("Failed to structure API data for password: %s \nReason: %s\n", p.Password, err)
+			return
+		}
+		AddToCache(shaPrefix, data)
+	}
+
+	for _, pwnedPassword := range data {
+		if pwnedPassword.Suffix == shaSuffix {
+			env.AllPasswords.Mu.Lock()
+			defer env.AllPasswords.Mu.Unlock()
+
+			env.AllPasswords.PasswordList[p.Sha] = PasswordPrevalence{
+				Password:   p.Password,
+				Prevalence: pwnedPassword.Count,
+			}
+		}
+	}
+}
+
+// Load passwords into channel for processing.
+func PasswordLoader(env *Environment) {
+	readFile, err := os.Open("input.txt")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	defer readFile.Close()
+
+	fileScanner := bufio.NewScanner(readFile)
+	fileScanner.Split(bufio.ScanLines)
+
+	for fileScanner.Scan() {
+		env.AllPasswords.LoaderWg.Add(1)
+		line := fileScanner.Text()
+		go func(line string) {
+			sha := calcSha(line)
+			password := Password{
+				Sha:        sha,
+				Password:   line,
+				Prevalence: 0,
+			}
+			env.PasswordCh <- &password
+		}(line)
+	}
+}
+
+// Processes passwords loaded into the channel by the PasswordLoader.
+func PasswordProcessor(env *Environment) {
+	for password := range env.PasswordCh {
+		if !password.IsLoaded(env) {
+			password.Load(env)
+		}
+		atomic.AddUint64(&env.ProcessedCount, 1)
+		env.AllPasswords.LoaderWg.Done()
+	}
+}
+
+// Returns the capitalised SHA1 value of a string
+func calcSha(password string) string {
+	text := password
+	data := []byte(text)
+	shaBytes := sha1.Sum(data)
+	shaString := fmt.Sprintf("%x", shaBytes)
+	resp := strings.ToUpper(shaString)
+	return resp
+}

--- a/go/lib/statistics.go
+++ b/go/lib/statistics.go
@@ -1,0 +1,74 @@
+package lib
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// Calculate the latency of API responses.
+func GetApiLatency(env *Environment) string {
+	env.ResponseStats.Mu.Lock()
+	defer env.ResponseStats.Mu.Unlock()
+
+	var total int64 = 0
+	for _, respTime := range env.ResponseStats.ResponseTimes {
+		total += respTime
+	}
+	if total == 0 {
+		return "Not Recorded."
+	}
+
+	responseCount := int64(len(env.ResponseStats.ResponseTimes))
+	if responseCount == 0 {
+		return "Not Recorded."
+	}
+
+	avgRespTime := total / responseCount
+
+	return fmt.Sprintf("%dms", avgRespTime)
+}
+
+// Calculate the percentage of API calls that were cached by Cloudflare.
+func CalcCfCache(apiRequestCount int64, cfCachedCount int64) string {
+
+	if apiRequestCount == 0 {
+		return "No Requests Made."
+	}
+	if cfCachedCount == 0 {
+		return "No Calls Cached."
+	}
+
+	percent := float64(cfCachedCount) / float64(apiRequestCount) * 100
+	response := fmt.Sprintf("%d (%.0f%%)", apiRequestCount, percent)
+
+	return response
+}
+
+// Update API statistics.
+func UpdateAPIStats(env *Environment, respTime int64, cfCacheStatus string) {
+	env.ResponseStats.Mu.Lock()
+	defer env.ResponseStats.Mu.Unlock()
+	env.ResponseStats.ResponseTimes = append(env.ResponseStats.ResponseTimes, respTime)
+
+	atomic.AddInt64(&env.ApiRequestCount, 1)
+
+	if cfCacheStatus == "HIT" || cfCacheStatus == "STALE" || cfCacheStatus == "REVALIDATED" {
+		atomic.AddInt64(&env.CfCachedCount, 1)
+	}
+}
+
+// Display results from collected runtime statistics.
+func PresentResults(env *Environment) {
+	runtime := time.Since(env.StartTime).Round(time.Millisecond)
+	processCount := atomic.LoadUint64(&env.ProcessedCount)
+	apiRequestCount := atomic.LoadInt64(&env.ApiRequestCount)
+	cfCachedCount := atomic.LoadInt64(&env.CfCachedCount)
+	passwordSeconds := (processCount * 1000) / uint64(runtime.Milliseconds())
+
+	fmt.Printf("Total Time Taken: %s \n", runtime)
+	fmt.Printf("Passwords Processed: %d @ %d/sec \n", processCount, passwordSeconds)
+	fmt.Printf("API Calls: %d \n", apiRequestCount)
+	fmt.Printf("Average API Response: %s \n", GetApiLatency(env))
+	fmt.Printf("Cloudflare Cached Calls: %s \n", CalcCfCache(apiRequestCount, cfCachedCount))
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"psc/lib"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	env := lib.SetupEnvironment()
+
+	lib.PasswordLoader(env)
+
+	for i := 0; i < *env.Flags.Parallelism; i++ {
+		go lib.PasswordProcessor(env)
+	}
+
+	env.AllPasswords.LoaderWg.Wait()
+
+	writeOutput(env.AllPasswords.PasswordList)
+
+	lib.PresentResults(env)
+}
+
+// Write the output file containing the prevalence of each password.
+func writeOutput(passwords lib.PasswordList) {
+	var output strings.Builder
+
+	for _, password := range passwords {
+		countAsStr := strconv.Itoa(password.Prevalence)
+		output.WriteString(fmt.Sprintf("%s,%s\n", password.Password, countAsStr))
+	}
+	data := []byte(output.String())
+
+	os.WriteFile("output.txt", data, 0644)
+}


### PR DESCRIPTION
This is an initial implementation of the password speed challenge in Go. It uses channels and goroutines to increase throughput.

I ran it on an AWS c7g.4xlarge (16 Core, 32GB RAM, Burst Network 15Gbps) instance with the following results:
```
## 300 goroutines ##
Total Time Taken: 46.621s
Passwords Processed: 100000 @ 2144/sec
API Calls: 99922
Average API Response: 96ms
Cloudflare Cached Calls: 99922 (100%)

## 400 goroutines ##
Total Time Taken: 37.087s
Passwords Processed: 100000 @ 2696/sec
API Calls: 99923
Average API Response: 94ms
Cloudflare Cached Calls: 99923 (100%)

## 500 goroutines ##
Total Time Taken: 37.282s
Passwords Processed: 100000 @ 2682/sec
API Calls: 99922
Average API Response: 106ms
Cloudflare Cached Calls: 99922 (100%)

## Local Cache ##
Total Time Taken: 7.843s
Passwords Processed: 100000 @ 12750/sec
API Calls: 0
Average API Response: Not Recorded.
Cloudflare Cached Calls: No Requests Made.
```

> 🧷 Safety notes: The optimal number of goroutines can vary and pushing it too high appears to result in Cloudflare blocking requests as if it's a DDOS attack. 😅 I've set the default to 500 as it has been a reasonable balance of performance and stability for my testing.

Haven't accounted for the exact differences in `Passwords Processed` vs `API Calls` but seems much more predictable with smaller password files. I suspect duplicates are a possible consideration.